### PR TITLE
feat: improve web console routing

### DIFF
--- a/inspire.py
+++ b/inspire.py
@@ -124,7 +124,6 @@ def getOS():
                 raise Exception
             else:
                 ports = instantboxManager.get_container_ports(container_name)
-                webshell_port = ports['1588/tcp']
                 if os_port is not None:
                     open_port = ports['{}/tcp'.format(os_port)]
 
@@ -142,7 +141,7 @@ def getOS():
                     'message':
                     'SUCCESS',
                     'shareUrl':
-                    'http://{}:{}'.format(SERVERURL, webshell_port),
+                    '/console/{}'.format(container_name),
                     'openPort':
                     open_port,
                     'statusCode':


### PR DESCRIPTION
Previously we were creating and binding a host port for each instantbox created. This PR updates it so that is no longer necessary. Instead, users will be taken to `/console/{instantbox_id}` for the web console.

Pros:
* More secure, harder to brute force and guess.
* It can be secured (SSL) along with the main site without additional effort.

Cons:
* It creates a docker network for each host, which has limit of ~30 per host? Personally, I think that's plenty for now, if necessary, this # can be further extended by putting all containers on the same network after securing all instantbox docker images by adding firewall. 
* I changed the random naming to use lowercase letters and numbers to get around a docker dns casing limitation. `moby/moby#21169`

For future reference: change network mode to overlay in swarm mode, this will solve the network limitations mentioned in Cons (1). 

The accompanied front-end PR is here: instantbox/instantbox-frontend#14